### PR TITLE
Fix MOTD banner text, support env var for config version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,7 +84,7 @@ system_motd_banner: |
 
 # The version of the motd configuration. If set to an empty string, the git hash
 #  of the project containing the originating playbook will be used.
-system_motd_config_version: "{{ awx_project_revision | default('') }}"
+system_motd_config_version: "{{ awx_project_revision | default(lookup('env', 'PROJECT_VERSION') | default('')) }}"
 
 # List of filenames that should be removed if they're in the update-motd.d directory
 system_motd_blacklist: []

--- a/templates/etc/motd.d/90-ansible-warning.j2
+++ b/templates/etc/motd.d/90-ansible-warning.j2
@@ -1,6 +1,5 @@
 
 WARNING: This host is managed by Ansible! Manual changes may revert automagically!
-         See https://github.com/influxdata/cloud1-awx/tree/GLaDOS for details.
 
 Configuration Status
   Timestamp: {{ ansible_date_time.iso8601 }}

--- a/templates/etc/update-motd.d/90-ansible-warning.j2
+++ b/templates/etc/update-motd.d/90-ansible-warning.j2
@@ -2,7 +2,6 @@
 cat << 'EOF'
 
 WARNING: This host is managed by Ansible! Manual changes may revert automagically!
-         See https://github.com/influxdata/cloud1-awx/tree/GLaDOS for details.
 
 Configuration Status
   Timestamp: {{ ansible_date_time.iso8601 }}


### PR DESCRIPTION
Support the `PROJECT_VERSION` env var for setting the configuration version in the MOTD banner